### PR TITLE
fix bluebird import and pass through jo options

### DIFF
--- a/jpeg-autorotate.js
+++ b/jpeg-autorotate.js
@@ -1,11 +1,9 @@
-const Promise = require('Bluebird');
+const Promise = require('bluebird');
 const jo = require('jpeg-autorotate');
 
-const jpegAutorotate = buffer => {
+const jpegAutorotate = (buffer, options) => {
     return new Promise((resolve, reject) => {
-        jo.rotate(buffer, {
-            quality: 100
-        }, (err, newBuffer) => {
+        jo.rotate(buffer, options, (err, newBuffer) => {
             if(err) {
                 return reject(err);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagemin-jpeg-autorotate",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "plugin imagein auto rotation of images",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Change import from "Bluebird" to "bluebird" to fix
  "module not found" error on case-sensitive filesystems
- Pass through options argument from index.js to the
  call to jo.rotate instead of always using quality:100